### PR TITLE
Change package version number from 0.8.3 to 0.996.1.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,9 @@
-python-mecab (1:0.8.3-1) unstable; urgency=medium
+python-mecab (0.996.1-1) unstable; urgency=medium
 
   [ Zack Weinberg ]
-  * Switch upstream to “mecab-python3” PyPI package, which runs SWIG
-    at build time rather than embedding SWIG-generated code, and (therefore)
-    supports Python 3.  This package is versioned independently from
-    MeCab itself, which requires an epoch.
+  * Switch upstream to “mecab-python3” PyPI package, which runs
+    SWIG at build time rather than embedding SWIG-generated code,
+    and therefore supports Python 3.
   * Build using pybuild.
   * Add python3 binary packages.
   * Remove obsolete Provides: lines.

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ swig_opts = ['-shadow', '-c++']
 swig_opts.extend("-I"+d for d in inc_dir)
 
 setup(name = "mecab-python3",
-    version = '0.8.3',
+    version = '0.996.1',
     description = 'python wrapper for mecab: Morphological Analysis engine',
     long_description = read_file('README.rst'),
     maintainer = 'Tatsuro Yasukawa',


### PR DESCRIPTION
I would like to increase the version number of this package from 0.8.3 to 0.996.1, matching the MeCab library's version number with a suffix.

There are two reasons for this change.  Most important, the SWIG
definitions we ship are copied out of the MeCab library’s source tree
(see <https://github.com/taku910/mecab/tree/master/mecab/swig>).
This makes clear which version of those definitions we have.

Also, Debian already ships a version of these bindings that are
numbered mostly consistently with the MeCab library (python-mecab,
currently version 0.99.6-2) but are stuck without Python 3 support.
I would like to try to replace them with this package, but if we we
stick to version 0.8.3, they will have to put an “epoch” on their
package numbering in order to do that, and they prefer to avoid that
whenever possible.