### PR TITLE
tox.ini: Find undefined names

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 envlist = py27,py35,py36,py37
 
 [testenv]
-deps = flake8 pytest
-commands = flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+deps =
+  flake8
+  pytest
+commands =
+  flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
   pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py27,py35,py36,py37
+envlist = py27,py34,py35,py36,py37
 
 [testenv]
-deps =
+deps = |
   flake8
   pytest
-commands =
-  flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+commands = |
+  flake8 . --count --select=F821 --show-source --statistics
   pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
-envlist = py27,py34,py35,py36,py37
+envlist = py27,py35,py36,py37
 
 [testenv]
-deps = pytest
-commands = pytest
+deps = flake8,pytest
+commands = flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  pytest

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27,py34,py35,py36,py37
 
 [testenv]
-deps = |
+deps =
   flake8
   pytest
 commands = |

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,6 @@
 envlist = py27,py35,py36,py37
 
 [testenv]
-deps = flake8,pytest
+deps = flake8 pytest
 commands = flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
   pytest

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,6 @@ envlist = py27,py34,py35,py36,py37
 deps =
   flake8
   pytest
-commands = |
+commands =
   flake8 . --count --select=F821 --show-source --statistics
   pytest


### PR DESCRIPTION
This test is looking for ___undefined names___ these are often names that were removed from the language (xrange, unicode, basestring), or missing imports (see __sys__ below), or missing __self__ parameters in methods, or missing __global__ declarations, or refactoring mistakes, or just plain typos.  These are the kind of issues that a compiler would flag in a compiled language.  These issues are not _style_ related.

$ __flake8 . --count --select=F821 --show-source --statistics__
```
./src/MeCab/__init__.py:87:14: F821 undefined name '_Tagger'
class Tagger(_Tagger):
             ^
./src/MeCab/__init__.py:90:13: F821 undefined name '_Tagger'
            _Tagger.__init__(self, *args)
            ^
./src/MeCab/__init__.py:95:13: F821 undefined name '_Model'
class Model(_Model):
            ^
./src/MeCab/__init__.py:98:13: F821 undefined name '_Model'
            _Model.__init__(self, *args)
            ^
./scripts/travis-deploy.py:16:9: F821 undefined name 'sys'
        sys.exit(1)
        ^
./scripts/travis-deploy.py:32:13: F821 undefined name 'sys'
            sys.exit(1)
            ^
./scripts/travis-build.py:39:34: F821 undefined name 'DISTRO'
                         .format(DISTRO))
                                 ^
./scripts/travis-build.py:114:38: F821 undefined name 'DISTRO'
                             .format(DISTRO))
                                     ^
./scripts/utils.py:76:37: F821 undefined name 'status'
                sh_quote(argv[0]), -status))
                                    ^
./scripts/utils.py:106:37: F821 undefined name 'status'
                sh_quote(argv[0]), -status))
                                    ^
./scripts/utils.py:169:26: F821 undefined name 'dest'
                sh_quote(dest), e.strerror))
                         ^
11    F821 undefined name 'DISTRO'
11
```