### PR TITLE
import sys for access to sys.exit() on lines 17 and 33

### DIFF
--- a/scripts/travis-deploy.py
+++ b/scripts/travis-deploy.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 
+import sys
 from glob import glob
 from os import environ
 from sys import stderr


### PR DESCRIPTION
https://travis-ci.org/SamuraiT/mecab-python3/jobs/520952518#L693-L698

$ __python3 -c "sys.exit(0)"__  # --> NameError: name 'sys' is not defined