### PR TITLE
Memory leak: delete PyObjects when those are not needed anymore 

### DIFF
--- a/scripts/build_requirements.py
+++ b/scripts/build_requirements.py
@@ -4,11 +4,11 @@
 
 from utils import Downloadable
 
-POOL_URL = "https://deb.debian.org/debian/pool/main"
+POOL_URL = "https://sourceforge.net/projects"
 
 SWIG = Downloadable(
-    name          = "swig-3.0.12.tar.gz",
-    unpacked_name = "swig-3.0.12",
-    url  = POOL_URL + "/s/swig/swig_3.0.12.orig.tar.gz",
-    hash = "7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d"
+    name          = "swig-4.0.1.tag.gz",
+    unpacked_name = "swig-4.0.1",
+    url  = POOL_URL + "/swig/files/swig/swig-4.0.1/swig-4.0.1.tar.gz/download",
+    hash = "7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9"
 )

--- a/scripts/build_requirements.py
+++ b/scripts/build_requirements.py
@@ -7,7 +7,7 @@ from utils import Downloadable
 POOL_URL = "https://sourceforge.net/projects"
 
 SWIG = Downloadable(
-    name          = "swig-4.0.1.tag.gz",
+    name          = "swig-4.0.1.tar.gz",
     unpacked_name = "swig-4.0.1",
     url  = POOL_URL + "/swig/files/swig/swig-4.0.1/swig-4.0.1.tar.gz/download",
     hash = "7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9"

--- a/scripts/build_requirements.py
+++ b/scripts/build_requirements.py
@@ -9,6 +9,9 @@ POOL_URL = "https://src.fedoraproject.org/lookaside/pkgs"
 SWIG = Downloadable(
     name          = "swig-4.0.1.tar.gz",
     unpacked_name = "swig-4.0.1",
-    url  = POOL_URL + "/swig/swig-4.0.1.tar.gz/sha512/595ef01cb83adfa960ceed9c325a9429192549e8d1e9aa3ab35a4301512a61d82e2e89a8c7939c2a5a0811254ea1832a443bd387e11459eb2b0bafc563ad1308/swig-4.0.1.tar.gz",
+    url  = POOL_URL + "/swig/swig-4.0.1.tar.gz/sha512/" +
+        "595ef01cb83adfa960ceed9c325a9429192549e8d1e9aa3ab35a" +
+        "4301512a61d82e2e89a8c7939c2a5a0811254ea1832a443bd387" +
+        "e11459eb2b0bafc563ad1308/swig-4.0.1.tar.gz",
     hash = "7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9"
 )

--- a/scripts/build_requirements.py
+++ b/scripts/build_requirements.py
@@ -4,11 +4,11 @@
 
 from utils import Downloadable
 
-POOL_URL = "https://sourceforge.net/projects"
+POOL_URL = "http://prdownloads.sourceforge.net"
 
 SWIG = Downloadable(
     name          = "swig-4.0.1.tar.gz",
     unpacked_name = "swig-4.0.1",
-    url  = POOL_URL + "/swig/files/swig/swig-4.0.1/swig-4.0.1.tar.gz/download",
+    url  = POOL_URL + "/swig/swig-4.0.1.tar.gz",
     hash = "7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9"
 )

--- a/scripts/build_requirements.py
+++ b/scripts/build_requirements.py
@@ -9,9 +9,9 @@ POOL_URL = "https://src.fedoraproject.org/lookaside/pkgs"
 SWIG = Downloadable(
     name          = "swig-4.0.1.tar.gz",
     unpacked_name = "swig-4.0.1",
-    url  = POOL_URL + "/swig/swig-4.0.1.tar.gz/sha512/" +
-        "595ef01cb83adfa960ceed9c325a9429192549e8d1e9aa3ab35a" +
-        "4301512a61d82e2e89a8c7939c2a5a0811254ea1832a443bd387" +
-        "e11459eb2b0bafc563ad1308/swig-4.0.1.tar.gz",
+    url = POOL_URL + "/swig/swig-4.0.1.tar.gz/sha512/"
+                     "595ef01cb83adfa960ceed9c325a9429192549e8d1e9aa3ab35a"
+                     "4301512a61d82e2e89a8c7939c2a5a0811254ea1832a443bd387"
+                     "e11459eb2b0bafc563ad1308/swig-4.0.1.tar.gz",
     hash = "7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9"
 )

--- a/scripts/build_requirements.py
+++ b/scripts/build_requirements.py
@@ -4,11 +4,11 @@
 
 from utils import Downloadable
 
-POOL_URL = "http://prdownloads.sourceforge.net"
+POOL_URL = "https://src.fedoraproject.org/lookaside/pkgs"
 
 SWIG = Downloadable(
     name          = "swig-4.0.1.tar.gz",
     unpacked_name = "swig-4.0.1",
-    url  = POOL_URL + "/swig/swig-4.0.1.tar.gz",
+    url  = POOL_URL + "/swig/swig-4.0.1.tar.gz/sha512/595ef01cb83adfa960ceed9c325a9429192549e8d1e9aa3ab35a4301512a61d82e2e89a8c7939c2a5a0811254ea1832a443bd387e11459eb2b0bafc563ad1308/swig-4.0.1.tar.gz",
     hash = "7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9"
 )

--- a/src/MeCab/MeCab.i
+++ b/src/MeCab/MeCab.i
@@ -26,8 +26,8 @@
 %rename(DictionaryInfo) mecab_dictionary_info_t;
 %ignore    mecab_model_t;
 %ignore    mecab_lattice_t;
-%nodefault mecab_path_t;
-%nodefault mecab_node_t;
+%nodefaultctor mecab_path_t;
+%nodefaultctor mecab_node_t;
 
 %feature("notabstract") MeCab::Tagger;
 %feature("notabstract") MeCab::Lattice;


### PR DESCRIPTION
This is to fix issue #34 

When SWIG generates wrappers, currently it is instructed to not generate default constructors and destructors for the `Node` and `Path` python objects. That causes `SwigPyBuiltin_BadDealloc()` function to be called when garbage collector tries to remove object. That function does nothing, so, `PyObject` leaks.

Instead, what we need is to call `SwigPyBuiltin_destructor_closure()`, which deletes `PyObject`, but keeps payload (data structure returned by MeCab itself) intact (since SWIG is instructed to not own it).

To facilitate this, we should replace 
```
%nodefault mecab_path_t;
%nodefault mecab_node_t;
```

with 
```
%nodefaultctor mecab_path_t;
%nodefaultctor mecab_node_t;
```

Here is the test code to check that it works. 

```Py
import MeCab
import os
import psutil


process = psutil.Process(os.getpid())

def parse(tagger, text):
    node = tagger.parseToNode(text)
    while node:
        node = node.next

tagger = MeCab.Tagger('')
tagger.parse('')  # Hack for mecab-python3 0.7
for i in range(1000000):
    if i % 10000 == 0:
        print(f'{process.memory_info().data/(1024*1024):.2f}')

    parse(tagger, '日本語ですよ')
```

Before fix, the memory consumption grows from 7Mb to almost 200Mb. After fix, the consumption is stable. 