### PR TITLE
build: add support for python 3.14

### DIFF
--- a/.github/macos-build.sh
+++ b/.github/macos-build.sh
@@ -51,7 +51,7 @@ sudo make install
 cd ../..
 
 python -m pip install --upgrade setuptools wheel pip setuptools-scm
-python -m pip install cibuildwheel==2.21.3
+python -m pip install cibuildwheel==3.2.1
 
 # don't bother with pypy wheels
 export CIBW_SKIP="pp*"

--- a/.github/workflows/entrypoint.sh
+++ b/.github/workflows/entrypoint.sh
@@ -18,7 +18,7 @@ make install
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 
 # Build the wheels
-for PYVER in cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313; do
+for PYVER in cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp314-cp314; do
   # build the wheels
   /opt/python/$PYVER/bin/pip wheel /github/workspace -w /github/workspace/wheels || { echo "Failed while buiding $PYVER wheel"; exit 1; }
 done

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -17,6 +17,7 @@ jobs:
           3.11
           3.12
           3.13
+          3.14
     - name: Cache mecab
       id: cache-mecab
       uses: actions/cache@v4
@@ -63,6 +64,7 @@ jobs:
           3.11
           3.12
           3.13
+          3.14
 
     - name: Cache mecab
       id: cache-mecab

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -17,6 +17,7 @@ jobs:
           3.11
           3.12
           3.13
+          3.14
     - name: Download and build MeCab
       shell: bash
       run: |

--- a/.github/workflows/test_manylinux.yml
+++ b/.github/workflows/test_manylinux.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14" ]
     env:
       PYTHON: python${{ matrix.python-version }}
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - python-version: 3.8
             py-short: 38
@@ -28,6 +28,9 @@ jobs:
           - python-version: "3.13"
             py-short: 313
             py-short2: 313
+          - python-version: "3.14"
+            py-short: 314
+            py-short2: 314
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.build_py import build_py as _build_py
-from distutils import log as setup_log
+
 
 SRCDIR = os.path.abspath(os.path.dirname(__file__))
 USE_BUNDLED_LIBMECAB = "BUNDLE_LIBMECAB" in os.environ
@@ -139,8 +139,7 @@ def discard_swig_wrappers(ext):
             except (OSError, IOError):
                 swig_py_wrapper = None
             if swig_py_wrapper is not None:
-                setup_log.info("discarding wrapper module {} for {}"
-                               .format(swig_py_wrapper, src))
+                print(f"discarding wrapper module {swig_py_wrapper} for {src}")
                 os.unlink(swig_py_wrapper)
 
 
@@ -232,6 +231,7 @@ setup(name = "mecab-python3",
           "Programming Language :: Python :: 3.11",
           "Programming Language :: Python :: 3.12",
           "Programming Language :: Python :: 3.13",
+          "Programming Language :: Python :: 3.14",
           "Intended Audience :: Developers",
           "Intended Audience :: Science/Research",
           "Natural Language :: Japanese",


### PR DESCRIPTION
fixes: https://github.com/SamuraiT/mecab-python3/issues/110

https://docs.python.org/3.12/library/distutils.html
distutils is deprecated, thus setup_log is not longer support after 3.12